### PR TITLE
Change get method to use Slack's object ID rather than internal DB _id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
     var storage = {
         teams: {
             get: function(id, cb) {
-                Teams.findById(id, unwrapFromList(cb));
+                Teams.findOne({id: id}, unwrapFromList(cb));
             },
             save: function(data, cb) {
                 Teams.findAndModify({
@@ -47,7 +47,7 @@ module.exports = function(config) {
         },
         users: {
             get: function(id, cb) {
-                Users.findById(id, unwrapFromList(cb));
+                Users.findOne({id: id}, unwrapFromList(cb));
             },
             save: function(data, cb) {
                 Users.findAndModify({
@@ -63,7 +63,7 @@ module.exports = function(config) {
         },
         channels: {
             get: function(id, cb) {
-                Channels.findById(id, unwrapFromList(cb));
+                Channels.findOne({id: id}, unwrapFromList(cb));
             },
             save: function(data, cb) {
                 Channels.findAndModify({

--- a/tests/index.js
+++ b/tests/index.js
@@ -26,7 +26,7 @@ describe('Users', function() {
         mongodbDriver.users.save(testObject, function(err, data) {
             (err === null).should.be.true;
 
-            mongodbDriver.users.get(data._id, function(err, data) {
+            mongodbDriver.users.get(testObject.id, function(err, data) {
                 (err === null).should.be.true;
 
                 data.foo.should.equal(testObject.foo);
@@ -70,7 +70,7 @@ describe('Channels', function() {
         mongodbDriver.channels.save(testObject, function(err, data) {
             (err === null).should.be.true;
 
-            mongodbDriver.channels.get(data._id, function(err, data) {
+            mongodbDriver.channels.get(testObject.id, function(err, data) {
                 (err === null).should.be.true;
 
                 data.foo.should.equal(testObject.foo);
@@ -114,7 +114,7 @@ describe('Teams', function() {
         mongodbDriver.teams.save(testObject, function(err, data) {
             (err === null).should.be.true;
 
-            mongodbDriver.teams.get(data._id, function(err, data) {
+            mongodbDriver.teams.get(testObject.id, function(err, data) {
                 (err === null).should.be.true;
 
                 data.foo.should.equal(testObject.foo);


### PR DESCRIPTION
This will allow the Mongo storage to work with example bots
