### PR TITLE
Add a Find method to get filtered results instead of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ var Botkit = require('botkit'),
 // then you can use the Botkit storage api, make sure you have an id property
 var beans = {id: 'cool', beans: ['pinto', 'garbanzo']};
 controller.storage.teams.save(beans);
-beans = controller.storage.teams.get('cool');
+controller.storage.teams.get('cool', function(error, beans){
+    // do something with beans
+});
 
+```
+
+You can also get all entries from a table or find a selected set depending on a parameters.
+
+```
+storage.users.all(function(error, users){
+    // do something with users
+});
+```
+
+```
+storage.users.find({team_id: team_id}, function(error, users){
+    // do something with users
+});
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ module.exports = function(config) {
  *
  * @param {Object} db A reference to the MongoDB instance
  * @param {String} zone The table to query in the database
- * @returns {{get: get, save: save, all: all}}
+ * @returns {{get: get, save: save, all: all, find: find}}
  */
 function getStorage(db, zone) {
     var table = db.get(zone);
@@ -51,6 +51,9 @@ function getStorage(db, zone) {
         },
         all: function(cb) {
             table.find({}, cb);
+        },
+        find: function(data, cb){
+            table.find(data, cb);
         }
     };
 }


### PR DESCRIPTION
Hi!

I thought it would be useful to have a `find` method to be able to select a set of results from the DB instead of the all. It's useful when handling multiples team bots and getting the all users for a specific team but there are many other use cases I think.

I also added some documentation for this new method along with precisions on how to use the `get` and `all` method. It wasn't clear to me from the start and I had to look at the sources so it might be useful to others. I took the liberty to correct the `get` method especially since it works with a callback and doesn't return the user.

Cheers!