### PR TITLE
Feature add optional mongo options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
         throw new Error('Need to provide mongo address.');
     }
 
-    var db = monk(config.mongoUri),
+    var db = config.mongoOptions ? monk(config.mongoUri, config.mongoOptions) : monk(config.mongoUri),
         storage = {};
 
     ['teams', 'channels', 'users'].forEach(function(zone) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ var monk = require('monk');
 /**
  * botkit-storage-mongo - MongoDB driver for Botkit
  *
- * @param  {Object} config Must contain a mongoUri property
+ * @param  {Object} config Must contain a mongoUri property and May contain a mongoOptions object containing mongo options (auth,db,server,...).
  * @return {Object} A storage object conforming to the Botkit storage interface
  */
 module.exports = function(config) {
@@ -17,8 +17,9 @@ module.exports = function(config) {
         throw new Error('Need to provide mongo address.');
     }
 
-    var db = config.mongoOptions ? monk(config.mongoUri, config.mongoOptions) : monk(config.mongoUri),
-        storage = {};
+    var db = monk(config.mongoUri, config.mongoOptions);
+
+    var storage = {};
 
     ['teams', 'channels', 'users'].forEach(function(zone) {
         storage[zone] = getStorage(db, zone);


### PR DESCRIPTION
Some Mongo clusters require additional options to be passed to establish a connection. Those options could be passed to the URI but where there is a lot if them, passing a JSON is easier. 
This is a requirement in most enterprise clouds.