### PR TITLE
Update save to use findOneAndUpdate instead of deprecated method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,11 +50,11 @@ function getStorage(db, zone) {
             return table.findOne({id: id}, cb);
         },
         save: function(data, cb) {
-            return table.findAndModify({
+            return table.findOneAndUpdate({
                 id: data.id
             }, data, {
                 upsert: true,
-                new: true
+                returnNewDocument: true
             }, cb);
         },
         all: function(cb) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -17,7 +17,7 @@ describe('Mongo', function() {
         collectionObj = {
             find: sinon.stub(),
             findOne: sinon.stub(),
-            findAndModify: sinon.stub()
+            findOneAndUpdate: sinon.stub()
         };
 
         collectionMock = {
@@ -57,15 +57,15 @@ describe('Mongo', function() {
 
         describe(method + '.save', function() {
 
-            it('should call findAndModify', function() {
+            it('should call findOneAndUpdate', function() {
                 var data = {id: 'walterwhite'},
                     cb = sinon.stub();
 
                 Storage(config)[method].save(data, cb);
-                collectionObj.findAndModify.should.be.calledWith(
+                collectionObj.findOneAndUpdate.should.be.calledWith(
                     {id: 'walterwhite'},
                     data,
-                    {upsert: true, 'new': true},
+                    {upsert: true, 'returnNewDocument': true},
                     cb
                 );
             });


### PR DESCRIPTION
This updates the save method to use findOneAndUpdate instead of the deprecated findAndModify method. 

Closes #24.