### PR TITLE
Catching mongo error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ module.exports = function(config) {
 
     var db = monk(config.mongoUri, config.mongoOptions);
 
+    db.catch(function(err) {
+      throw new Error(err)
+    });
+
     var storage = {};
 
     var tables = ['teams', 'channels', 'users'];


### PR DESCRIPTION
Sometimes, when I run my bot and I didn't notice that mongo process was down, I don't get any error messages from the botkit storage, just a weird behavior on my bot, until I realize mongo is turned off.

With this simple catch, you can check the mongo connection before running any bot.