### PR TITLE
feature(monk): pass options to monk .find() calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,14 @@ function getStorage(db, zone) {
         all: function(cb) {
             return table.find({}, cb);
         },
-        find: function(data, cb) {
-            return table.find(data, cb);
+        find: function(data, opts, cb) {
+            // keep things backwards compatible with the previous API signature
+            // where the consumer only passes query data and a callback
+            if (typeof opts === 'function') {
+                return table.find(data, opts);
+            }
+
+            return table.find(data, opts, cb);
         },
         delete: function(id, cb) {
             return table.findOneAndDelete({id: id}, cb);

--- a/tests/index.js
+++ b/tests/index.js
@@ -92,5 +92,18 @@ describe('Mongo', function() {
                 collectionObj.findOneAndDelete.should.be.calledWith({id: 'walterwhite'}, cb);
             });
         });
+
+        describe(method + '.find', function() {
+            it('should pass options to find', function() {
+                var cb = sinon.stub(),
+                    options = {
+                        limit: 1
+                    };
+
+
+                Storage(config)[method].find({}, options, cb);
+                collectionObj.find.should.be.calledwith({}, options, cb);
+            });
+        });
     });
 });


### PR DESCRIPTION
This allows the user to easily apply limit and sort options along with various other Mongo options to the `.find()` query via the standard API that monk exposes.

I added a test, but it is rather unclear how the tests for this project are supposed to work and I could never get more than the first two to pass. I'd be happy to revisit the tests if you can tell me what I need to do to get them running.

Closes #39 